### PR TITLE
refactor(tags): add extra when create/update tags

### DIFF
--- a/lib/groupher_server/cms/models/article_tag.ex
+++ b/lib/groupher_server/cms/models/article_tag.ex
@@ -11,7 +11,7 @@ defmodule GroupherServer.CMS.Model.ArticleTag do
   alias CMS.Model.{Author, Community}
 
   @required_fields ~w(thread title color author_id community_id)a
-  @updatable_fields ~w(thread title color community_id group)a
+  @updatable_fields ~w(thread title color community_id group extra)a
 
   @type t :: %ArticleTag{}
   schema "article_tags" do
@@ -19,6 +19,7 @@ defmodule GroupherServer.CMS.Model.ArticleTag do
     field(:color, :string)
     field(:thread, :string)
     field(:group, :string)
+    field(:extra, {:array, :string})
 
     belongs_to(:community, Community)
     belongs_to(:author, Author)

--- a/lib/groupher_server_web/schema/cms/cms_types.ex
+++ b/lib/groupher_server_web/schema/cms/cms_types.ex
@@ -279,6 +279,7 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:color, :string)
     field(:thread, :string)
     field(:group, :string)
+    field(:extra, list_of(:string))
 
     field(:author, :user, resolve: dataloader(CMS, :author))
     field(:community, :community, resolve: dataloader(CMS, :community))

--- a/lib/groupher_server_web/schema/cms/mutations/community.ex
+++ b/lib/groupher_server_web/schema/cms/mutations/community.ex
@@ -133,6 +133,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Community do
       arg(:community_id, non_null(:id))
       arg(:group, :string)
       arg(:thread, :thread, default_value: :post)
+      arg(:extra, list_of(:string))
 
       middleware(M.Authorize, :login)
       middleware(M.PassportLoader, source: :community)
@@ -149,6 +150,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Community do
       arg(:color, :rainbow_color)
       arg(:group, :string)
       arg(:thread, :thread, default_value: :post)
+      arg(:extra, list_of(:string))
 
       middleware(M.Authorize, :login)
       middleware(M.PassportLoader, source: :community)

--- a/priv/repo/migrations/20210816040543_add_extra_to_tags.exs
+++ b/priv/repo/migrations/20210816040543_add_extra_to_tags.exs
@@ -1,0 +1,9 @@
+defmodule GroupherServer.Repo.Migrations.AddExtraToTags do
+  use Ecto.Migration
+
+  def change do
+    alter table(:article_tags) do
+      add(:extra, {:array, :string})
+    end
+  end
+end

--- a/test/groupher_server/cms/article_tags/post_tag_test.exs
+++ b/test/groupher_server/cms/article_tags/post_tag_test.exs
@@ -24,6 +24,13 @@ defmodule GroupherServer.Test.CMS.ArticleTag.PostTag do
       assert article_tag.group == article_tag_attrs.group
     end
 
+    test "create article tag with extra data", ~m(community article_tag_attrs user)a do
+      tag_attrs = Map.merge(article_tag_attrs, %{extra: ["menuID", "menuID2"]})
+      {:ok, article_tag} = CMS.create_article_tag(community, :post, tag_attrs, user)
+
+      assert article_tag.extra == ["menuID", "menuID2"]
+    end
+
     test "can update an article tag", ~m(community article_tag_attrs user)a do
       {:ok, article_tag} = CMS.create_article_tag(community, :post, article_tag_attrs, user)
 

--- a/test/groupher_server/cms/comments/archive_test.exs
+++ b/test/groupher_server/cms/comments/archive_test.exs
@@ -27,7 +27,6 @@ defmodule GroupherServer.Test.CMS.Comments.Archive do
   end
 
   describe "[cms comment archive]" do
-    @tag :wip
     test "can archive comments", ~m(comment_long_ago)a do
       {:ok, _} = CMS.archive_articles(:comment)
 
@@ -41,7 +40,6 @@ defmodule GroupherServer.Test.CMS.Comments.Archive do
       assert archived_comment.id == comment_long_ago.id
     end
 
-    @tag :wip
     test "can not edit archived comment" do
       {:ok, _} = CMS.archive_articles(:comment)
 
@@ -55,7 +53,6 @@ defmodule GroupherServer.Test.CMS.Comments.Archive do
       assert reason |> is_error?(:archived)
     end
 
-    @tag :wip
     test "can not delete archived comment" do
       {:ok, _} = CMS.archive_articles(:comment)
 

--- a/test/groupher_server_web/query/cms/article_tags_test.exs
+++ b/test/groupher_server_web/query/cms/article_tags_test.exs
@@ -25,6 +25,7 @@ defmodule GroupherServer.Test.Query.CMS.ArticleTags do
           title
           color
           thread
+          extra
           community {
             id
             title

--- a/test/groupher_server_web/query/cms/comments/post_comment_test.exs
+++ b/test/groupher_server_web/query/cms/comments/post_comment_test.exs
@@ -30,7 +30,7 @@ defmodule GroupherServer.Test.Query.Comments.PostComment do
       }
     }
     """
-    @tag :wip
+
     test "guest user can get basic archive info", ~m(guest_conn post user)a do
       thread = :post
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -386,7 +386,8 @@ defmodule GroupherServer.Support.Factory do
       group: "cool",
       # community: Faker.Pizza.topping(),
       community: mock(:community),
-      author: mock(:author)
+      author: mock(:author),
+      extra: []
       # user_id: 1
     }
   end


### PR DESCRIPTION
solve no-common tags in cool-guide, jobs , meetup etc..